### PR TITLE
fix: prevent auto-switch when editing in board view

### DIFF
--- a/src/core/services/viewSwitcher.ts
+++ b/src/core/services/viewSwitcher.ts
@@ -9,6 +9,37 @@ export class ViewSwitcher {
   
   constructor(private plugin: AgileBoardPlugin) {}
 
+  private resolveLeafForFile(file: TFile, preferredViewTypes: readonly string[]): WorkspaceLeaf | null {
+    const activeLeaf = this.plugin.app.workspace.activeLeaf;
+    const isPreferredType = (viewType: string): boolean => preferredViewTypes.includes(viewType);
+    const leafFilePath = (leaf: WorkspaceLeaf): string | undefined =>
+      (leaf.view as unknown as { file?: TFile }).file?.path;
+
+    if (
+      activeLeaf &&
+      isPreferredType(activeLeaf.view.getViewType()) &&
+      leafFilePath(activeLeaf) === file.path
+    ) {
+      return activeLeaf;
+    }
+
+    for (const viewType of preferredViewTypes) {
+      const matchingLeaf = this.plugin.app.workspace
+        .getLeavesOfType(viewType)
+        .find((leaf) => leafFilePath(leaf) === file.path);
+
+      if (matchingLeaf) {
+        return matchingLeaf;
+      }
+    }
+
+    if (activeLeaf && leafFilePath(activeLeaf) === file.path) {
+      return activeLeaf;
+    }
+
+    return activeLeaf ?? null;
+  }
+
   private markAsManualChange(file: TFile): void {
     // Notifier le ModelDetector qu'un changement manuel a eu lieu
     const plugin = this.plugin as unknown as { modelDetector?: { markUserManualChange: (path: string) => void } };
@@ -18,8 +49,7 @@ export class ViewSwitcher {
   }
 
   async switchToBoardView(file: TFile): Promise<void> {
-    // Utiliser activeLeaf au lieu de getLeaf() pour éviter le bug d'Obsidian avec les onglets épinglés
-    const leaf = this.plugin.app.workspace.activeLeaf;
+    const leaf = this.resolveLeafForFile(file, ["markdown", AGILE_BOARD_VIEW_TYPE]);
     if (!leaf) return;
 
     await leaf.setViewState({
@@ -29,8 +59,7 @@ export class ViewSwitcher {
   }
 
   async switchToMarkdownView(file: TFile): Promise<void> {
-    // Utiliser activeLeaf au lieu de getLeaf() pour éviter le bug d'Obsidian avec les onglets épinglés
-    const leaf = this.plugin.app.workspace.activeLeaf;
+    const leaf = this.resolveLeafForFile(file, [AGILE_BOARD_VIEW_TYPE, "markdown"]);
     if (!leaf) return;
 
     await leaf.setViewState({
@@ -40,8 +69,7 @@ export class ViewSwitcher {
   }
 
   async switchToSourceMode(file: TFile): Promise<void> {
-    // Utiliser activeLeaf au lieu de getLeaf() pour éviter le bug d'Obsidian avec les onglets épinglés
-    const leaf = this.plugin.app.workspace.activeLeaf;
+    const leaf = this.resolveLeafForFile(file, [AGILE_BOARD_VIEW_TYPE, "markdown"]);
     if (!leaf) return;
 
     await leaf.setViewState({

--- a/src/main.ts
+++ b/src/main.ts
@@ -19,8 +19,8 @@ export default class AgileBoardPlugin extends Plugin {
   public layoutService: LayoutService;
   public fileSynchronizer: FileSynchronizer;
   public viewSwitcher: ViewSwitcher;
+  public modelDetector: ModelDetector;
   public settings: PluginSettings = DEFAULT_PLUGIN_SETTINGS;
-  private modelDetector: ModelDetector;
   private lifecycleManager: LifecycleManager;
   private logger = createContextLogger('AgileBoardPlugin');
 

--- a/src/views/agileBoardView.ts
+++ b/src/views/agileBoardView.ts
@@ -149,6 +149,9 @@ export class AgileBoardView extends FileView {
   private async onFrameContentChanged(title: string, newContent: string): Promise<void> {
     if (!this.file) return;
 
+    // Mark this as a manual change to prevent auto-switch during editing
+    this.plugin.modelDetector.markUserManualChange(this.file.path);
+
     // Notifier le synchroniseur que le changement vient de cette vue
     this.plugin.fileSynchronizer.notifyBoardViewChange(this.file);
 

--- a/src/views/agileBoardView.ts
+++ b/src/views/agileBoardView.ts
@@ -160,10 +160,15 @@ export class AgileBoardView extends FileView {
       return;
     }
 
-    // Tenter d'utiliser l'API Editor si une vue Markdown active existe
-    const activeView = this.app.workspace.getActiveViewOfType(MarkdownView);
+    // Utiliser l'éditeur uniquement si la feuille active est réellement une vue Markdown
+    const activeLeaf = this.app.workspace.activeLeaf;
+    const activeView = activeLeaf?.view;
 
-    if (activeView && activeView.file?.path === this.file.path && activeView.editor) {
+    if (
+      activeView instanceof MarkdownView &&
+      activeView.file?.path === this.file.path &&
+      activeView.editor
+    ) {
       // MÉTHODE OPTIMALE: Utiliser editor.replaceRange() pour modifier seulement la section
       const editor = activeView.editor;
 


### PR DESCRIPTION
## Problem
When editing a section in board view, the plugin would automatically switch back to markdown view after ~100ms, interrupting the editing workflow.

## Root Cause
The metadata cache fires a 'resolved' event when content updates. The ModelDetector evaluates the auto-switch decision but wasn't aware that the user was actively editing in board view, so it would trigger an unwanted switch.

## Solution
- Mark files as manually changed when the user edits sections in board view
- Expose \`modelDetector\` as a public property so views can communicate with it
- Now when editing triggers, the manual change flag prevents the auto-switch

## Testing
After reload, try editing sections in board view. Edits should continue without interruption.