### PR TITLE
docs: update all READMEs to v0.9.2 with print improvements section

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -1,4 +1,4 @@
-![version](https://img.shields.io/badge/version-0.9.1-blue) ![Obsidian](https://img.shields.io/badge/Obsidian-%E2%89%A50.15.0-7C3AED) ![1.13+](https://img.shields.io/badge/1.13%2B-compatible-brightgreen) ![Desktop only](https://img.shields.io/badge/Plattform-Desktop-lightgrey)
+![version](https://img.shields.io/badge/version-0.9.2-blue) ![Obsidian](https://img.shields.io/badge/Obsidian-%E2%89%A50.15.0-7C3AED) ![1.13+](https://img.shields.io/badge/1.13%2B-compatible-brightgreen) ![Desktop only](https://img.shields.io/badge/Plattform-Desktop-lightgrey)
 
 🌍 Lies dies in anderen Sprachen:
 [English](README.md) | [Français](README.fr.md) | [Español](README.es.md) | [Português](README.pt.md) | [简体中文](README.zh-CN.md) | [Русский](README.ru.md)
@@ -14,6 +14,14 @@
 ---
 
 ## 🆕 Neuigkeiten
+
+### v0.9.2 — Verbesserte Board-Druckfunktion
+
+- **Rasterskalierung**: Rahmen passen sich der Papiergröße (Hoch- oder Querformat) an, ohne zu überlaufen
+- **Kopf- & Fußzeile**: Dateititel oben, Plugin-Version unten rechts
+- **Callouts**: korrekt gestylt beim Drucken
+- **Obsidian Bases**: Karten und Tabellen werden sauber gedruckt — UI entfernt, Datumsangaben als `TT.MM.JJJJ HH:MM:SS` formatiert, Eigenschaftsbeschriftungen angezeigt (außer dem redundanten «name»)
+- **Aufgabenlisten**: Kontrollkästchen mit korrektem Abstand erhalten
 
 ### v0.9.1 — Kompatibilitätspatch für Obsidian 1.13.0
 Die Größenänderungs-Handles des Layout-Editors funktionierten nach Obsidians Chromium-Aktualisierung in v1.13.0 nicht mehr. Dieser Patch stellt den visuellen Editor auf allen unterstützten Versionen vollständig wieder her.

--- a/README.es.md
+++ b/README.es.md
@@ -1,4 +1,4 @@
-![version](https://img.shields.io/badge/version-0.9.1-blue) ![Obsidian](https://img.shields.io/badge/Obsidian-%E2%89%A50.15.0-7C3AED) ![1.13+](https://img.shields.io/badge/1.13%2B-compatible-brightgreen) ![Desktop only](https://img.shields.io/badge/plataforma-escritorio-lightgrey)
+![version](https://img.shields.io/badge/version-0.9.2-blue) ![Obsidian](https://img.shields.io/badge/Obsidian-%E2%89%A50.15.0-7C3AED) ![1.13+](https://img.shields.io/badge/1.13%2B-compatible-brightgreen) ![Desktop only](https://img.shields.io/badge/plataforma-escritorio-lightgrey)
 
 🌍 Lee esto en otros idiomas:
 [English](README.md) | [Français](README.fr.md) | [Deutsch](README.de.md) | [Português](README.pt.md) | [简体中文](README.zh-CN.md) | [Русский](README.ru.md)
@@ -14,6 +14,14 @@
 ---
 
 ## 🆕 Novedades
+
+### v0.9.2 — Impresión del tablero mejorada
+
+- **Escala de cuadrícula**: los marcos se adaptan al tamaño del papel (vertical u horizontal) sin desbordarse
+- **Encabezado y pie de página**: título del archivo arriba, versión del plugin abajo a la derecha
+- **Callouts**: correctamente estilizados en la impresión
+- **Obsidian Bases**: tarjetas y tablas se imprimen limpiamente — interfaz eliminada, fechas formateadas como `DD/MM/AAAA HH:MM:SS`, etiquetas de propiedades mostradas (excepto el redundante «name»)
+- **Listas de tareas**: casillas de verificación conservadas con espacio adecuado
 
 ### v0.9.1 — Parche de compatibilidad para Obsidian 1.13.0
 Los controladores de redimensionamiento del editor de layouts dejaron de funcionar tras la actualización de Chromium de Obsidian en v1.13.0. Este parche restaura completamente el editor visual en todas las versiones compatibles.

--- a/README.fr.md
+++ b/README.fr.md
@@ -1,4 +1,4 @@
-![version](https://img.shields.io/badge/version-0.9.1-blue) ![Obsidian](https://img.shields.io/badge/Obsidian-%E2%89%A50.15.0-7C3AED) ![1.13+](https://img.shields.io/badge/1.13%2B-compatible-brightgreen) ![Desktop only](https://img.shields.io/badge/plateforme-desktop-lightgrey)
+![version](https://img.shields.io/badge/version-0.9.2-blue) ![Obsidian](https://img.shields.io/badge/Obsidian-%E2%89%A50.15.0-7C3AED) ![1.13+](https://img.shields.io/badge/1.13%2B-compatible-brightgreen) ![Desktop only](https://img.shields.io/badge/plateforme-desktop-lightgrey)
 
 🌍 Lire dans une autre langue :
 [English](README.md) | [Español](README.es.md) | [Deutsch](README.de.md) | [Português](README.pt.md) | [简体中文](README.zh-CN.md) | [Русский](README.ru.md)
@@ -14,6 +14,14 @@
 ---
 
 ## 🆕 Nouveautés
+
+### v0.9.2 — Impression améliorée
+
+- **Mise à l'échelle de la grille** : les cadres s'adaptent à la taille du papier (portrait ou paysage) sans débordement
+- **En-tête & pied de page** : titre du fichier en haut, version du plugin en bas à droite
+- **Callouts** : correctement stylés à l'impression
+- **Obsidian Bases** : cartes et tableaux s'impriment proprement — interface supprimée, dates formatées en `JJ/MM/AAAA HH:MM:SS`, labels de propriétés affichés (sauf « name » redondant)
+- **Listes de tâches** : cases à cocher préservées avec un espace adapté
 
 ### v0.9.1 — Compatibilité Obsidian 1.13.0
 Les poignées de redimensionnement de l'éditeur de layouts ne répondaient plus depuis la mise à jour Chromium embarquée dans Obsidian 1.13.0. Ce correctif restaure complètement l'éditeur visuel sur toutes les versions supportées.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![version](https://img.shields.io/badge/version-0.9.1-blue) ![Obsidian](https://img.shields.io/badge/Obsidian-%E2%89%A50.15.0-7C3AED) ![1.13+](https://img.shields.io/badge/1.13%2B-compatible-brightgreen) ![Desktop only](https://img.shields.io/badge/platform-desktop-lightgrey)
+![version](https://img.shields.io/badge/version-0.9.2-blue) ![Obsidian](https://img.shields.io/badge/Obsidian-%E2%89%A50.15.0-7C3AED) ![1.13+](https://img.shields.io/badge/1.13%2B-compatible-brightgreen) ![Desktop only](https://img.shields.io/badge/platform-desktop-lightgrey)
 
 🌍 Read this in other languages:
 [Français](README.fr.md) | [Español](README.es.md) | [Deutsch](README.de.md) | [Português](README.pt.md) | [简体中文](README.zh-CN.md) | [Русский](README.ru.md)
@@ -14,6 +14,14 @@
 ---
 
 ## 🆕 What's New
+
+### v0.9.2 — Improved print board
+
+- **Grid scaling**: frames scale to fit the paper size (portrait or landscape) without overflowing
+- **Header & footer**: file title at the top, plugin version at the bottom right
+- **Callouts**: correctly styled in print output
+- **Obsidian Bases**: cards and tables print cleanly — toolbar stripped, dates formatted as `DD/MM/YYYY HH:MM:SS`, property labels shown (except the redundant "name")
+- **Task lists**: checkboxes preserved with proper spacing
 
 ### v0.9.1 — Obsidian 1.13.0 compatibility fix
 Resize handles in the layout editor stopped working after Obsidian's Chromium upgrade in v1.13.0. This patch fully restores the visual editor on all supported versions.

--- a/README.pt.md
+++ b/README.pt.md
@@ -1,4 +1,4 @@
-![version](https://img.shields.io/badge/version-0.9.1-blue) ![Obsidian](https://img.shields.io/badge/Obsidian-%E2%89%A50.15.0-7C3AED) ![1.13+](https://img.shields.io/badge/1.13%2B-compatible-brightgreen) ![Desktop only](https://img.shields.io/badge/plataforma-desktop-lightgrey)
+![version](https://img.shields.io/badge/version-0.9.2-blue) ![Obsidian](https://img.shields.io/badge/Obsidian-%E2%89%A50.15.0-7C3AED) ![1.13+](https://img.shields.io/badge/1.13%2B-compatible-brightgreen) ![Desktop only](https://img.shields.io/badge/plataforma-desktop-lightgrey)
 
 🌍 Leia isto em outros idiomas:
 [English](README.md) | [Français](README.fr.md) | [Español](README.es.md) | [Deutsch](README.de.md) | [简体中文](README.zh-CN.md) | [Русский](README.ru.md)
@@ -14,6 +14,14 @@
 ---
 
 ## 🆕 Novidades
+
+### v0.9.2 — Impressão do quadro melhorada
+
+- **Escala da grelha**: as molduras adaptam-se ao tamanho do papel (retrato ou paisagem) sem transbordar
+- **Cabeçalho e rodapé**: título do ficheiro no topo, versão do plugin no canto inferior direito
+- **Callouts**: corretamente estilizados na impressão
+- **Obsidian Bases**: cartões e tabelas são impressos de forma limpa — interface removida, datas formatadas como `DD/MM/AAAA HH:MM:SS`, etiquetas de propriedades mostradas (exceto o redundante «name»)
+- **Listas de tarefas**: caixas de verificação preservadas com espaçamento adequado
 
 ### v0.9.1 — Correção de compatibilidade para Obsidian 1.13.0
 Os controladores de redimensionamento do editor de layouts deixaram de funcionar após a atualização do Chromium do Obsidian na v1.13.0. Este patch restaura completamente o editor visual em todas as versões suportadas.

--- a/README.ru.md
+++ b/README.ru.md
@@ -1,4 +1,4 @@
-![version](https://img.shields.io/badge/version-0.9.1-blue) ![Obsidian](https://img.shields.io/badge/Obsidian-%E2%89%A50.15.0-7C3AED) ![1.13+](https://img.shields.io/badge/1.13%2B-compatible-brightgreen) ![Desktop only](https://img.shields.io/badge/%D0%BF%D0%BB%D0%B0%D1%82%D1%84%D0%BE%D1%80%D0%BC%D0%B0-%D0%9F%D0%9A-lightgrey)
+![version](https://img.shields.io/badge/version-0.9.2-blue) ![Obsidian](https://img.shields.io/badge/Obsidian-%E2%89%A50.15.0-7C3AED) ![1.13+](https://img.shields.io/badge/1.13%2B-compatible-brightgreen) ![Desktop only](https://img.shields.io/badge/%D0%BF%D0%BB%D0%B0%D1%82%D1%84%D0%BE%D1%80%D0%BC%D0%B0-%D0%9F%D0%9A-lightgrey)
 
 🌍 Читать на других языках:
 [English](README.md) | [Français](README.fr.md) | [Español](README.es.md) | [Deutsch](README.de.md) | [Português](README.pt.md) | [简体中文](README.zh-CN.md)
@@ -14,6 +14,14 @@
 ---
 
 ## 🆕 Что нового
+
+### v0.9.2 — Улучшенная печать доски
+
+- **Масштабирование сетки**: рамки адаптируются к размеру бумаги (книжная или альбомная) без переполнения
+- **Верхний и нижний колонтитулы**: название файла вверху, версия плагина внизу справа
+- **Выноски (Callouts)**: корректно стилизованы при печати
+- **Obsidian Bases**: карточки и таблицы печатаются чисто — интерфейс удалён, даты отформатированы как `ДД/ММ/ГГГГ ЧЧ:ММ:СС`, метки свойств отображаются (кроме избыточного «name»)
+- **Списки задач**: флажки сохранены с правильными отступами
 
 ### v0.9.1 — Исправление совместимости с Obsidian 1.13.0
 Маркеры изменения размера в редакторе макетов перестали работать после обновления Chromium в Obsidian v1.13.0. Этот патч полностью восстанавливает визуальный редактор на всех поддерживаемых версиях.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,4 +1,4 @@
-![version](https://img.shields.io/badge/version-0.9.1-blue) ![Obsidian](https://img.shields.io/badge/Obsidian-%E2%89%A50.15.0-7C3AED) ![1.13+](https://img.shields.io/badge/1.13%2B-compatible-brightgreen) ![Desktop only](https://img.shields.io/badge/%E5%B9%B3%E5%8F%B0-%E4%BB%85%E6%A1%8C%E9%9D%A2%E7%AB%AF-lightgrey)
+![version](https://img.shields.io/badge/version-0.9.2-blue) ![Obsidian](https://img.shields.io/badge/Obsidian-%E2%89%A50.15.0-7C3AED) ![1.13+](https://img.shields.io/badge/1.13%2B-compatible-brightgreen) ![Desktop only](https://img.shields.io/badge/%E5%B9%B3%E5%8F%B0-%E4%BB%85%E6%A1%8C%E9%9D%A2%E7%AB%AF-lightgrey)
 
 🌍 用其他语言阅读:
 [English](README.md) | [Français](README.fr.md) | [Español](README.es.md) | [Deutsch](README.de.md) | [Português](README.pt.md) | [Русский](README.ru.md)
@@ -14,6 +14,14 @@
 ---
 
 ## 🆕 最新动态
+
+### v0.9.2 — 看板打印功能改进
+
+- **网格缩放**：框架自适应纸张大小（纵向或横向），不再溢出
+- **页眉和页脚**：文件标题显示在顶部，插件版本显示在右下角
+- **标注块**：打印时样式正确
+- **Obsidian Bases**：卡片和表格可干净打印——工具栏已移除，日期格式化为 `DD/MM/YYYY HH:MM:SS`，属性标签正常显示（冗余的 "name" 除外）
+- **任务列表**：复选框保留，并有适当间距
 
 ### v0.9.1 — Obsidian 1.13.0 兼容性修复
 Obsidian v1.13.0 的 Chromium 升级导致布局编辑器中的调整大小手柄失效。此补丁在所有受支持的版本上完全恢复了可视化编辑器的功能。


### PR DESCRIPTION
## Summary

- Bump version badge to `0.9.2` in all 7 READMEs (EN, FR, ES, DE, PT, ZH-CN, RU)
- Add v0.9.2 "What's New" section in each language describing the print board improvements

🤖 Generated with [Claude Code](https://claude.com/claude-code)