### PR TITLE
feat: remove empty frame placeholder text

### DIFF
--- a/locales/de.json
+++ b/locales/de.json
@@ -82,9 +82,6 @@
     "toolbar": {
       "info": "{count} Rahmen{plural} • 24×24 Raster"
     },
-    "empty": {
-      "placeholder": "Klicken Sie hier, um zu schreiben..."
-    },
     "sidebar": {
       "selection": {
         "title": "Ausgewählter Rahmen",

--- a/locales/en.json
+++ b/locales/en.json
@@ -82,9 +82,6 @@
     "toolbar": {
       "info": "{count} frame{plural} • 24×24 Grid"
     },
-    "empty": {
-      "placeholder": "Click to start writing..."
-    },
     "sidebar": {
       "selection": {
         "title": "Selected Frame",

--- a/locales/es.json
+++ b/locales/es.json
@@ -82,9 +82,6 @@
     "toolbar": {
       "info": "{count} marco{plural} • Cuadrícula 24×24"
     },
-    "empty": {
-      "placeholder": "Haz clic para empezar a escribir..."
-    },
     "sidebar": {
       "selection": {
         "title": "Marco Seleccionado",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -82,9 +82,6 @@
     "toolbar": {
       "info": "{count} cadre{plural} • Grille 24×24"
     },
-    "empty": {
-      "placeholder": "Cliquez pour commencer à écrire..."
-    },
     "sidebar": {
       "selection": {
         "title": "Cadre sélectionné",

--- a/locales/pt.json
+++ b/locales/pt.json
@@ -82,9 +82,6 @@
     "toolbar": {
       "info": "{count} moldura{plural} • Grade 24×24"
     },
-    "empty": {
-      "placeholder": "Clique para começar a escrever..."
-    },
     "sidebar": {
       "selection": {
         "title": "Moldura Selecionada",

--- a/locales/ru.json
+++ b/locales/ru.json
@@ -82,9 +82,6 @@
     "toolbar": {
       "info": "{count} фрейм{plural} • Сетка 24×24"
     },
-    "empty": {
-      "placeholder": "Нажмите, чтобы начать писать..."
-    },
     "sidebar": {
       "selection": {
         "title": "Выбранный фрейм",

--- a/locales/zh-CN.json
+++ b/locales/zh-CN.json
@@ -82,9 +82,6 @@
     "toolbar": {
       "info": "{count} 个框架 • 24×24 网格"
     },
-    "empty": {
-      "placeholder": "点击开始输入..."
-    },
     "sidebar": {
       "selection": {
         "title": "选中的框架",

--- a/src/components/markdown/MarkdownRenderer.ts
+++ b/src/components/markdown/MarkdownRenderer.ts
@@ -313,14 +313,7 @@ export class MarkdownRenderer extends BaseUIComponent {
    * Affiche un placeholder quand le contenu est vide.
    */
   private renderPlaceholder(): void {
-    if (!this.containerEl) return;
-
-    const placeholder = this.containerEl.createDiv();
-    placeholder.textContent = "Cliquez pour commencer à écrire...";
-    placeholder.style.cssText = `
-      color: var(--text-muted);
-      font-style: italic;
-    `;
+    // Empty frame — no placeholder shown
   }
 
   /**

--- a/src/components/markdown/markdownBox.ts
+++ b/src/components/markdown/markdownBox.ts
@@ -291,35 +291,7 @@ export class MarkdownBox {
     try {
       this.previewEl.empty();
 
-      // Force le conteneur à occuper tout l'espace disponible
-      this.previewEl.style.position = "relative";
-      this.previewEl.style.width = "100%";
-      this.previewEl.style.height = "100%";
-      this.previewEl.style.minHeight = "60px"; // adapte si besoin
-
-      if (!this.content.trim()) {
-        const placeholder = document.createElement("div");
-        placeholder.innerText = "Cliquez pour commencer à écrire…";
-        // Styles en dur pour occuper tout l'espace et centrer le texte
-        placeholder.style.position = "absolute";
-        placeholder.style.top = "0";
-        placeholder.style.left = "0";
-        placeholder.style.right = "0";
-        placeholder.style.bottom = "0";
-        placeholder.style.width = "100%";
-        placeholder.style.height = "100%";
-        placeholder.style.display = "flex";
-        placeholder.style.alignItems = "center";
-        placeholder.style.justifyContent = "center";
-        placeholder.style.opacity = "0.5";
-        placeholder.style.cursor = "text";
-        placeholder.style.userSelect = "none";
-        placeholder.style.fontStyle = "italic";
-        this.previewEl.appendChild(placeholder);
-      } else {
-        // Nettoie le style si contenu non vide
-        this.previewEl.style.position = "";
-        this.previewEl.style.minHeight = "";
+      if (this.content.trim()) {
         await MarkdownRenderer.render(
           this.app,
           this.content,

--- a/src/core/components/markdownPreview.ts
+++ b/src/core/components/markdownPreview.ts
@@ -106,12 +106,7 @@ export class MarkdownPreview extends BaseUIComponent {
    * Affiche l'état vide avec placeholder.
    */
   private renderEmptyState(): void {
-    if (!this.containerEl) return;
-    
-    const placeholder = ElementFactory.createEmptyPlaceholder(
-      "Cliquez pour commencer à écrire..."
-    );
-    this.containerEl.appendChild(placeholder);
+    // Empty frame — no placeholder shown
   }
 
   /**

--- a/src/views/agileBoardView.ts
+++ b/src/views/agileBoardView.ts
@@ -496,6 +496,9 @@ export class AgileBoardView extends FileView {
       if (contentEl) {
         const clone = contentEl.cloneNode(true) as HTMLElement;
 
+        // Empty-frame placeholder has no place in print output.
+        clone.querySelectorAll('.agile-board-placeholder').forEach(e => e.remove());
+
         // Remove SVG icon elements — Lucide/Obsidian icons render as garbled
         // text without Obsidian's icon CSS/fonts.
         clone.querySelectorAll('svg').forEach(e => e.remove());

--- a/src/views/markdownSubView.ts
+++ b/src/views/markdownSubView.ts
@@ -301,20 +301,7 @@ export class MarkdownSubView {
   }
 
   private renderEmptyState(): void {
-    if (!this.previewEl) return;
-    
-    const placeholder = this.previewEl.createDiv("empty-frame");
-    placeholder.style.cssText = `
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      height: 100%;
-      min-height: 80px;
-      color: var(--text-muted);
-      font-style: italic;
-      cursor: text;
-    `;
-    placeholder.textContent = t('editor.empty.placeholder');
+    // Empty frame — no placeholder shown
   }
 
 

--- a/src/views/nativeMarkdownView.ts
+++ b/src/views/nativeMarkdownView.ts
@@ -119,18 +119,7 @@ export class NativeMarkdownView {
   }
 
   private renderEmptyState(): void {
-    const placeholder = this.previewContainer.createDiv('empty-placeholder');
-    placeholder.style.cssText = `
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      height: 100%;
-      min-height: 80px;
-      color: var(--text-muted);
-      font-style: italic;
-      cursor: text;
-    `;
-    placeholder.textContent = "Cliquez pour commencer à écrire...";
+    // Empty frame — no placeholder shown
   }
 
   private renderFallback(): void {


### PR DESCRIPTION
## Summary

- Remove "Cliquez pour commencer à écrire..." from all 5 rendering paths (markdownBox, MarkdownRenderer, markdownPreview, nativeMarkdownView, markdownSubView)
- Remove unused `editor.empty.placeholder` i18n key from all 7 locales
- Remove placeholder from print output (DOM clone in agileBoardView)

🤖 Generated with [Claude Code](https://claude.com/claude-code)